### PR TITLE
Include shared source directory in Docker builds

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -18,6 +18,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 # Copy source files needed for client build
 COPY tsconfig.json vite.config.ts index.html ./
 COPY src/client ./src/client
+COPY src/shared ./src/shared
 COPY public ./public
 
 # Build the client

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -18,6 +18,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 # Copy source files
 COPY tsconfig.json esbuild.mjs ./
 COPY src/server ./src/server
+COPY src/shared ./src/shared
 
 # Build the server
 RUN pnpm build:server


### PR DESCRIPTION
## Summary
Updated both client and server Dockerfiles to include the `src/shared` directory during the build process. This ensures that shared code dependencies are available to both the client and server builds.

## Changes
- **Client Dockerfile**: Added `COPY src/shared ./src/shared` to include shared source files in the client build context
- **Server Dockerfile**: Added `COPY src/shared ./src/shared` to include shared source files in the server build context

## Details
Both the client and server applications now have access to shared code that likely contains common utilities, types, or interfaces used across the monorepo. This change ensures that the Docker build process can properly resolve imports from the shared directory during compilation.

https://claude.ai/code/session_01FCGM9USwv6qmWQ7ACk9PEG