### PR TITLE
Display card difficulty for reviewed cards in deck view

### DIFF
--- a/src/client/pages/DeckCardsPage.test.tsx
+++ b/src/client/pages/DeckCardsPage.test.tsx
@@ -327,6 +327,24 @@ describe("DeckCardsPage", () => {
 		expect(screen.getByText("1 lapses")).toBeDefined();
 	});
 
+	it("displays difficulty for reviewed cards", () => {
+		renderWithProviders({
+			initialDeck: mockDeck,
+			initialCards: mockCards,
+		});
+
+		expect(screen.getByText("D: 5.0")).toBeDefined();
+	});
+
+	it("does not show difficulty for new cards", () => {
+		renderWithProviders({
+			initialDeck: mockDeck,
+			initialCards: mockCards,
+		});
+
+		expect(screen.queryByText("D: 0.0")).toBeNull();
+	});
+
 	it("does not show description if deck has none", () => {
 		const deckWithoutDescription = { ...mockDeck, description: null };
 		renderWithProviders({

--- a/src/client/pages/DeckCardsPage.tsx
+++ b/src/client/pages/DeckCardsPage.tsx
@@ -162,6 +162,11 @@ function NoteGroupCard({
 							{card.lapses > 0 && (
 								<span className="text-muted">{card.lapses} lapses</span>
 							)}
+							{card.difficulty > 0 && (
+								<span className="text-muted">
+									D: {card.difficulty.toFixed(1)}
+								</span>
+							)}
 						</div>
 					))}
 				</div>


### PR DESCRIPTION
## Summary
Added display of card difficulty metric in the DeckCardsPage component, showing the difficulty rating for cards that have been reviewed.

## Key Changes
- Added conditional rendering of difficulty score in the card stats section of NoteGroupCard component
- Difficulty is only displayed for reviewed cards (when `card.difficulty > 0`)
- Difficulty value is formatted to one decimal place using `toFixed(1)`
- Added two test cases to verify the new behavior:
  - Test that difficulty is displayed for reviewed cards
  - Test that difficulty is not shown for new cards (difficulty = 0)

## Implementation Details
- The difficulty display follows the same pattern as the existing lapses display
- Uses the "text-muted" CSS class for consistent styling with other card metrics
- The condition `card.difficulty > 0` ensures new cards (with 0 difficulty) don't show the metric

https://claude.ai/code/session_019XoFbra6drKrZpHASUzKDq